### PR TITLE
add(channelpool) : channel pool for managing connections with upstream servers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,18 +38,28 @@
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj-core.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter-params.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
     </dependencies>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
-        <assertj-core.version>3.11.1</assertj-core.version>
+        <junit-jupiter-params.version>5.8.1</junit-jupiter-params.version>
+        <lombok.version>1.18.22</lombok.version>
         <logback.version>1.2.10</logback.version>
         <netty.version>4.1.73.Final</netty.version>
         <jackson-dataformat-yaml.version>2.13.0</jackson-dataformat-yaml.version>

--- a/core/src/main/java/channelpool/ChannelProxyPromise.java
+++ b/core/src/main/java/channelpool/ChannelProxyPromise.java
@@ -1,0 +1,18 @@
+package channelpool;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ChannelProxyPromise<C extends UpstreamChannel> extends ProxyPromise<C> {
+
+	public ChannelProxyPromise(EventExecutor eventExecutor, Promise<C> promise, C value, Throwable cause) {
+		super(eventExecutor, promise, value, cause);
+	}
+
+	@Override
+	public boolean isCompleted() {
+		return promise.isDone() && promise.isSuccess();
+	}
+}

--- a/core/src/main/java/channelpool/ProxyPromise.java
+++ b/core/src/main/java/channelpool/ProxyPromise.java
@@ -1,0 +1,244 @@
+package channelpool;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ProxyPromise<C> {
+	protected Promise<C> promise;
+	protected EventExecutor eventExecutor;
+	protected C value;
+	protected Throwable cause;
+
+	@Builder
+	protected ProxyPromise(@NonNull EventExecutor eventExecutor, @NonNull Promise<C> promise, C value,
+		Throwable cause) {
+		this.eventExecutor = eventExecutor;
+		this.promise = promise;
+		this.value = value;
+		this.cause = cause;
+	}
+
+	protected ProxyPromise<C> of(Throwable cause) {
+		return new ExceptionalProxyPromise(eventExecutor, promise, value, cause);
+	}
+
+	public ProxyPromise<C> throwException(Throwable cause) {
+		return this.of(cause);
+	}
+
+	public ProxyPromise<C> mapIfNot(Predicate<C> predicate, Consumer<C> function) {
+		try {
+			if (!hasExcetion() && predicate.negate().test(value)) {
+				function.accept(value);
+			}
+			return this;
+		} catch (Throwable cause) {
+			return throwException(cause);
+		}
+	}
+
+	public ProxyPromise<C> then(Predicate<C> predicate, BiConsumer<C, ? super ProxyPromise<C>> consumer) {
+		try {
+			if (!hasExcetion() && predicate.test(value)) {
+				consumer.accept(value, this);
+			}
+			return this;
+		} catch (Throwable cause) {
+			return throwException(cause);
+		}
+	}
+
+	public ProxyPromise<C> apply(Function<? super ProxyPromise<C>, ? extends ProxyPromise<C>> function) {
+		try {
+			if (!hasExcetion()) {
+				return function.apply(this);
+			}
+			return this;
+		} catch (Throwable cause) {
+			return throwException(cause);
+		}
+	}
+
+	public ProxyPromise<C> applyIfNot(Predicate<? super ProxyPromise<C>> predicate,
+		Consumer<? super ProxyPromise<C>> consumer) {
+		try {
+			if (!hasExcetion() && predicate.negate().test(this)) {
+				consumer.accept(this);
+			}
+			return this;
+		} catch (Throwable cause) {
+			return throwException(cause);
+		}
+	}
+
+	public ProxyPromise<C> applyIfNot(Predicate<? super ProxyPromise<C>> predicate,
+		BiConsumer<C, ? super ProxyPromise<C>> consumer) {
+		try {
+			if (!hasExcetion() && predicate.negate().test(this)) {
+				consumer.accept(value, this);
+			}
+			return this;
+		} catch (Throwable cause) {
+			return throwException(cause);
+		}
+	}
+
+	public ProxyPromise<C> throwIf(Predicate<? super ProxyPromise<C>> predicate,
+		BiConsumer<Throwable, ? super ProxyPromise<C>> consumer) {
+		if (predicate.test(this)) {
+			consumer.accept(cause, this);
+		}
+		return this;
+	}
+
+	public ProxyPromise<C> whenIf(Predicate<? super ProxyPromise<C>> predicate, Consumer<? super C> consumer) {
+		addListener(future -> {
+			if (predicate.test(this)) {
+				consumer.accept(future.getNow());
+			}
+		});
+		return this;
+	}
+
+	public ProxyPromise<C> applyAsync(Function<? super ProxyPromise<C>, ? extends ProxyPromise<C>> function) {
+		if (eventExecutor.inEventLoop()) {
+			return function.apply(this);
+		}
+		eventExecutor.execute(() -> {
+			function.apply(this);
+		});
+		return this;
+	}
+
+	public ProxyPromise<C> supply(Supplier<? extends ProxyPromise<C>> supplier) {
+		return supplier.get();
+	}
+
+	public ProxyPromise<C> retryIf(Predicate<? super Future<C>> predicate,
+		Function<? super ProxyPromise<C>, ? extends ProxyPromise<C>> retryAction,
+		Consumer<? super ProxyPromise<C>> failedActions) {
+		return new RetryPolicyPromise(eventExecutor, promise, value, cause)
+			.retry(predicate, retryAction, failedActions);
+	}
+
+	public ProxyPromise<C> addListener(GenericFutureListener<? extends Future<C>> listener) {
+		promise.addListeners(listener);
+		return this;
+	}
+
+	public ProxyPromise<C> trySuccessUncompletedPromise(C value) {
+		if (!isCompleted()) {
+			promise.trySuccess(value);
+		}
+		return this;
+	}
+
+	public ProxyPromise<C> tryFailureUncompletedPromise(Throwable exception) {
+		if (!isCompleted()) {
+			promise.tryFailure(exception);
+		}
+		return this;
+	}
+
+	public ProxyPromise<C> tryCancelUncompletedPromise() {
+		if (!isCompleted()) {
+			promise.cancel(false);
+		}
+		return this;
+	}
+
+	public Future<C> acquireFuture() {
+		return promise;
+	}
+
+	public boolean hasExcetion() {
+		return this.cause != null;
+	}
+
+	public boolean isCompleted() {
+		return promise.isDone();
+	}
+
+	public boolean isSuccess() {
+		return promise.isSuccess();
+	}
+
+	public boolean isDone() {
+		return promise.isDone();
+	}
+
+	public boolean isFailure() {
+		return promise.cause() != null;
+	}
+
+	public boolean isCancelled() {
+		return promise.isCancelled();
+	}
+
+	class ExceptionalProxyPromise extends ProxyPromise<C> {
+		public ExceptionalProxyPromise(EventExecutor eventExecutor, Promise<C> promise, C value, Throwable cause) {
+			super(eventExecutor, promise, value, cause);
+		}
+
+		@Override
+		public boolean isCompleted() {
+			return promise.isDone() && promise.cause() != null;
+		}
+
+		@Override
+		public ProxyPromise<C> throwException(Throwable cause) {
+			this.cause.addSuppressed(cause);
+			return this;
+		}
+
+		@Override
+		public boolean hasExcetion() {
+			return cause != null;
+		}
+	}
+
+	class RetryPolicyPromise extends ProxyPromise<C> {
+		private static final int DEFAULT_MAX_ATTEMPTS = 5;
+		private static final int DEFAULT_DELAY = 100;
+		private AtomicInteger retryCount = new AtomicInteger();
+
+		public RetryPolicyPromise(@NonNull EventExecutor eventExecutor, @NonNull Promise<C> promise, C value,
+			Throwable cause) {
+			super(eventExecutor, promise, value, cause);
+		}
+
+		public ProxyPromise<C> retry(Predicate<? super Future<C>> predicate,
+			Function<? super ProxyPromise<C>, ? extends ProxyPromise<C>> retryAction,
+			Consumer<? super ProxyPromise<C>> failedActions) {
+			if (retryCount.incrementAndGet() > DEFAULT_MAX_ATTEMPTS) {
+				failedActions.accept(this);
+				return this;
+			}
+			retryAction.apply(this).addListener(future -> {
+				if (predicate.test(future)) {
+					retryWhen(() -> retry(predicate, retryAction, failedActions), DEFAULT_DELAY, TimeUnit.MILLISECONDS);
+				}
+			});
+			return this;
+		}
+
+		private ProxyPromise<C> retryWhen(Runnable retryTask, int delay, TimeUnit timeUnit) {
+			eventExecutor.schedule(retryTask, delay, timeUnit);
+			return this;
+		}
+	}
+}

--- a/core/src/main/java/channelpool/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/channelpool/RoundRobinLoadBalancer.java
@@ -1,0 +1,18 @@
+package channelpool;
+
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RoundRobinLoadBalancer {
+	private final AtomicInteger index = new AtomicInteger();
+	private final List<SocketAddress> upstreams;
+
+	public RoundRobinLoadBalancer(List<SocketAddress> upstreams) {
+		this.upstreams = upstreams;
+	}
+
+	public SocketAddress acquireNextAddress() {
+		return upstreams.get(index.getAndIncrement() & upstreams.size() - 1);
+	}
+}

--- a/core/src/main/java/channelpool/UpstreamChannel.java
+++ b/core/src/main/java/channelpool/UpstreamChannel.java
@@ -1,0 +1,86 @@
+package channelpool;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.Promise;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor
+public class UpstreamChannel {
+	private static final AtomicReferenceFieldUpdater<UpstreamChannel, Object> STATE_UPDATER =
+		AtomicReferenceFieldUpdater.newUpdater(UpstreamChannel.class, Object.class, "state");
+
+	private SocketAddress serverHostAndPort;
+	private Channel channel;
+	private EventLoopGroup eventLoopGroup;
+	private EventLoop channelEventLoop;
+	private Bootstrap bootstrap;
+	private volatile Object state;
+	private AtomicInteger connectionSuccessCount;
+	private AtomicInteger connectionFailureCount;
+
+	private static final Object PENDING = new Object();
+	private static final Object ACTIVE = new Object();
+
+	public UpstreamChannel(SocketAddress serverHostAndPort, EventLoopGroup eventLoopGroup, Bootstrap bootstrap) {
+		this.eventLoopGroup = eventLoopGroup;
+		this.channelEventLoop = eventLoopGroup.next();
+		this.serverHostAndPort = serverHostAndPort;
+		this.bootstrap = bootstrap.clone().remoteAddress(serverHostAndPort)
+			.group(channelEventLoop);
+	}
+
+	public boolean isActive() {
+		return this.channel != null && this.channel.isActive();
+	}
+
+	public boolean hasConnected() {
+		if (STATE_UPDATER.compareAndSet(this, null, ACTIVE)) {
+			return false;
+		}
+		return true;
+	}
+
+	public ChannelProxyPromise<UpstreamChannel> createPromise() {
+		ChannelProxyPromise<UpstreamChannel> channelProxyPromise = createNewPromise();
+		allocateChannel(channelProxyPromise);
+		return channelProxyPromise;
+	}
+
+	public SocketAddress serverAddress() {
+		return serverHostAndPort;
+	}
+
+	private void allocateChannel(ChannelProxyPromise<UpstreamChannel> channelProxyPromise) {
+		channelProxyPromise
+			.mapIfNot(channel -> channel.hasConnected(), channel -> channel.tryConnecting())
+			.applyAsync(applyPromise -> applyPromise
+				.then(channel -> channel.isActive(),
+					(channel, promise) -> promise.trySuccessUncompletedPromise(channel))
+				.applyIfNot(promise -> promise.hasExcetion() || promise.isCompleted(),
+					promise -> promise.tryCancelUncompletedPromise())
+				.throwIf(promise -> promise.hasExcetion(),
+					(cause, promise) -> promise.tryFailureUncompletedPromise(cause)));
+	}
+
+	private void tryConnecting() {
+		ChannelFuture channelFuture = bootstrap.clone().connect();
+		this.channel = channelFuture.channel();
+	}
+
+	private ChannelProxyPromise<UpstreamChannel> createNewPromise() {
+		Promise<UpstreamChannel> promise = this.eventLoopGroup
+			.next()
+			.newPromise();
+		return new ChannelProxyPromise<>(channelEventLoop, promise, this, null);
+	}
+}

--- a/core/src/main/java/channelpool/UpstreamChannelPool.java
+++ b/core/src/main/java/channelpool/UpstreamChannelPool.java
@@ -1,0 +1,16 @@
+package channelpool;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UpstreamChannelPool {
+
+	private static Map<String, UpstreamChannels> upstreamChannels = new ConcurrentHashMap<>();
+
+	public ChannelProxyPromise<UpstreamChannel> provide(String key) {
+		return null;
+	}
+}

--- a/core/src/main/java/channelpool/UpstreamChannelProvider.java
+++ b/core/src/main/java/channelpool/UpstreamChannelProvider.java
@@ -1,0 +1,39 @@
+package channelpool;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.EventExecutor;
+
+public class UpstreamChannelProvider {
+	private final RoundRobinLoadBalancer roundRobinLoadBalancer;
+	private final UpstreamChannels upstreamChannels;
+	private final EventLoopGroup eventLoopGroup;
+
+	public UpstreamChannelProvider(List<SocketAddress> upstreams, EventLoopGroup eventLoopGroup, Bootstrap bootstrap) {
+		this.roundRobinLoadBalancer = new RoundRobinLoadBalancer(upstreams);
+		this.eventLoopGroup = eventLoopGroup;
+		this.upstreamChannels = new UpstreamChannels(eventLoopGroup, bootstrap);
+	}
+
+	public ChannelProxyPromise<UpstreamChannel> acquireNextChannel() {
+		return acquireNextChannel(createNewPromise());
+	}
+
+	public ChannelProxyPromise<UpstreamChannel> acquireNextChannel(
+		ChannelProxyPromise<UpstreamChannel> clientPromise) {
+		clientPromise.retryIf(future -> future.cause() != null, clientRetryPromise -> clientRetryPromise
+				.supply(() -> upstreamChannels.acquireChannel(roundRobinLoadBalancer.acquireNextAddress()))
+				.whenIf(channelPromise -> channelPromise.isSuccess(),
+					channel -> clientPromise.trySuccessUncompletedPromise(channel))
+			, retryPromise -> clientPromise.tryFailureUncompletedPromise(new IllegalStateException()));
+		return clientPromise;
+	}
+
+	private ChannelProxyPromise<UpstreamChannel> createNewPromise() {
+		EventExecutor eventExecutor = eventLoopGroup.next();
+		return new ChannelProxyPromise<>(eventExecutor, eventExecutor.newPromise(), null, null);
+	}
+}

--- a/core/src/main/java/channelpool/UpstreamChannels.java
+++ b/core/src/main/java/channelpool/UpstreamChannels.java
@@ -1,0 +1,33 @@
+package channelpool;
+
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.EventLoopGroup;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UpstreamChannels {
+	private final Map<SocketAddress, UpstreamChannel> upstreamChannels;
+	private final EventLoopGroup eventLoopGroup;
+	private Bootstrap bootstrap;
+
+	public UpstreamChannels(EventLoopGroup eventLoopGroup, Bootstrap bootstrap) {
+		this.upstreamChannels = new ConcurrentHashMap<>();
+		this.eventLoopGroup = eventLoopGroup;
+		this.bootstrap = bootstrap;
+	}
+
+	public ChannelProxyPromise<UpstreamChannel> acquireChannel(SocketAddress serverHostAndPort) {
+		UpstreamChannel upstreamChannel =  upstreamChannels.compute(serverHostAndPort, ((socketAddress, channel) -> {
+			if (channel == null) {
+				return new UpstreamChannel(serverHostAndPort, eventLoopGroup, bootstrap);
+			}
+
+			return channel;
+		}));
+		return upstreamChannel.createPromise();
+	}
+}

--- a/core/src/test/java/channelpool/ProxyPromiseTest.java
+++ b/core/src/test/java/channelpool/ProxyPromiseTest.java
@@ -1,0 +1,84 @@
+package channelpool;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+
+class ProxyPromiseTest {
+	private static final EventLoopGroup dummyGroup = new DefaultEventLoopGroup(2);
+
+	@Test
+	public void testCatchException() {
+		String expectedExceptionMessage = "A test exception occurred.";
+		EventExecutor eventExecutor = dummyGroup.next();
+		ProxyPromise<String> proxyPromise = new ProxyPromise(eventExecutor, eventExecutor.newPromise(), "Hello World",
+			null);
+
+		proxyPromise
+			.throwException(new RuntimeException(expectedExceptionMessage))
+			.applyIfNot(promise -> promise.hasExcetion(), promise -> promise.tryCancelUncompletedPromise())
+			.throwIf(promise -> promise.hasExcetion(), (cause, promise) -> promise.tryFailureUncompletedPromise(cause));
+
+		Future<String> future = proxyPromise.acquireFuture();
+		future.awaitUninterruptibly();
+
+		Assertions.assertFalse(future.isCancelled());
+		Assertions.assertTrue(future.cause() != null);
+		Assertions.assertEquals(expectedExceptionMessage, future.cause().getMessage());
+	}
+
+	@Test
+	public void testCancelPromise() {
+		EventExecutor eventExecutor = dummyGroup.next();
+		ProxyPromise<String> proxyPromise = new ProxyPromise(eventExecutor, eventExecutor.newPromise(), "Hello World",
+			null);
+
+		proxyPromise
+			.applyIfNot(promise -> promise.isCompleted(), promise -> promise.tryCancelUncompletedPromise())
+			.throwException(new RuntimeException())
+			.throwIf(promise -> promise.hasExcetion(), (cause, promise) -> promise.tryFailureUncompletedPromise(cause));
+
+		Future<String> future = proxyPromise.acquireFuture();
+		future.awaitUninterruptibly();
+
+		String expectResult = "CancellationException";
+		String actualResult = future.cause().toString();
+
+		Assertions.assertTrue(future.isCancelled());
+		Assertions.assertTrue(actualResult.contains(expectResult));
+	}
+
+	@Test
+	public void testSuccessPromise() {
+		String expectedValue = "Hello World";
+		EventExecutor eventExecutor = dummyGroup.next();
+		ProxyPromise<String> proxyPromise = new ProxyPromise(eventExecutor, eventExecutor.newPromise(), expectedValue,
+			null);
+
+		proxyPromise
+			.then(value -> value.equals(expectedValue), (value, promise) -> promise.trySuccessUncompletedPromise(value))
+			.applyIfNot(promise -> promise.isCompleted(), promise -> promise.tryCancelUncompletedPromise());
+
+		Future<String> future = proxyPromise.acquireFuture();
+		future.awaitUninterruptibly();
+
+		Assertions.assertTrue(future.isSuccess());
+		Assertions.assertEquals(expectedValue, future.getNow());
+	}
+
+	@Test
+	public void testInEventLoop() {
+		EventExecutor eventExecutor = dummyGroup.next();
+		ProxyPromise<String> proxyPromise = new ProxyPromise(eventExecutor, eventExecutor.newPromise(), null, null);
+		proxyPromise.applyAsync(promise -> {
+			Assertions.assertTrue(eventExecutor.inEventLoop(Thread.currentThread()));
+			return promise;
+		}).apply(promise -> promise.tryCancelUncompletedPromise());
+
+		proxyPromise.acquireFuture().awaitUninterruptibly();
+	}
+}

--- a/core/src/test/java/channelpool/UpstreamChannelProviderTest.java
+++ b/core/src/test/java/channelpool/UpstreamChannelProviderTest.java
@@ -1,0 +1,49 @@
+package channelpool;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class UpstreamChannelProviderTest {
+	private static final EventLoopGroup dummyGroup = new DefaultEventLoopGroup(5);
+	@Test
+	public void testAquireChannel(){
+		LocalAddress FIRST_SERVER_ADDRESS = new LocalAddress("first.id");
+		LocalAddress SECOND_SERVER_ADDRESS = new LocalAddress("second.id");
+
+		ServerBootstrap serverBootstrap = new ServerBootstrap()
+			.group(dummyGroup)
+			.channel(LocalServerChannel.class)
+			.childHandler(new LoggingHandler(LogLevel.DEBUG));
+
+		ChannelFuture secondServer = serverBootstrap.clone().bind(SECOND_SERVER_ADDRESS);
+		secondServer.awaitUninterruptibly();
+
+		Bootstrap bootstrap = new Bootstrap()
+			.channel(LocalChannel.class)
+			.handler(new LoggingHandler(LogLevel.DEBUG));
+
+		UpstreamChannelProvider upstreamChannelProvider = new UpstreamChannelProvider(
+			List.of(FIRST_SERVER_ADDRESS, SECOND_SERVER_ADDRESS), dummyGroup, bootstrap);
+
+		ChannelProxyPromise<UpstreamChannel> channelProxyPromise = upstreamChannelProvider.acquireNextChannel();
+		UpstreamChannel upstreamChannel = channelProxyPromise.promise.awaitUninterruptibly().getNow();
+
+		Assertions.assertTrue(upstreamChannel.isActive());
+		Assertions.assertEquals(upstreamChannel.serverAddress(), SECOND_SERVER_ADDRESS);
+	}
+}


### PR DESCRIPTION
1. upstream 서버들의 커넥션을 관리하기 위한 채널 풀 생성
 - 내부적으로 로드밸런서를 가지고 있으며 요청 순서에 따라 채널을 분배 합니다.
 - 채널이 닫혔을 경우 다른 채널 할당을 시도 합니다.
 - 채널 생성이 완료 되면 이벤트가 발생하고 전달 받은 ChannelProxyPromise 객체로 작업을 할 수 있습니다

2. UpstreamChannel 생성
 - upstream 서버로 연결되는 하나의 연결을 나타내는 객체입니다.
 - 활성화 상태인 객체만 할당이 가능 합니다.
 - 연결이 실패하면 해당 객체에서는 재연결 시도를 하지 않습니다.
 - 상태 변경 race-condition을 조절하기 위해 CAS를 사용합니다.

 3. UpstreamChannels 생성
  - upstream 주소와 UpstreamChannel객체를 맵핑하고 관리하기 위한 객체 입니다.
  - 현재 null인 경우만 새로 생성하고 나머지는 기존의 객체를 돌려줍니다.

 4. Promise 체이닝을 위한 ProxyPromise<C> 클래스 생성
   - Promise<T>를 랩핑하여 promise hell을 회피 위한 메소드 체이닝을 제공합니다.
   - ChannelProxyPromise<C>를 이용하면 UpstreamChannel과 관련된 연산을 할 수 있습니다.
   - ProxyPromise<C>는 다양한 타입을 받아 들일 수 있습니다.

 5. 의존성 추가 및 삭제
   - assertj-core:3.11.1 삭제
   - lombok:1.18.22 추가
   - junit-jupiter-param:5.8.1 추가

6. Upstream 클래스 삭제
   - UpstreamChannel생성에 따라 같은 역할을 하는 Upstream클래스를 삭제합니다.